### PR TITLE
Fix build: close conditional wrapper in dashboard (src/App.tsx)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -475,6 +475,7 @@ export default function Home() {
             </p>
           </CardContent>
         </Card>
+        )}
       </main>
 
       <Dialog open={openTransfer} onOpenChange={setOpenTransfer}>


### PR DESCRIPTION
Fix Netlify build failure
- Close missing conditional in dashboard: add closing `)}` after the Wallet Controls card in src/App.tsx.
- Error observed: Vite/esbuild “Unterminated regular expression” at App.tsx ~line 478 due to unclosed JSX expression.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/572fc3e3-84af-11f0-a94e-3eef481a796b/task/ae40fa41-1164-483a-9dfa-64bbb32ce46b))