### PR TITLE
Add Help & FAQ + header link; prep friendly toasts & mobile polish

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ import {
 } from "./lib/aa";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuLabel, DropdownMenuSeparator } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Toaster } from "@/components/ui/sonner";
+import { toast } from "sonner";
 
 export default function Dashboard() {
   const [bundlerUrl, setBundlerUrl] = useState("");
@@ -611,6 +613,7 @@ export default function Dashboard() {
       setStatus("Creating your seedless wallet...");
       await deployAccount();
     } catch (e: any) {
+      try { (toast as any)?.error?.("Transfer failed", { description: "Check the address and amount, then try again." }); } catch {}
       setStatus(`Error: ${e?.message || e}`);
     }
   }
@@ -687,6 +690,7 @@ export default function Dashboard() {
       }
       setOpenTransfer(false);
     } catch (e: any) {
+      try { (toast as any)?.error?.("Transfer failed", { description: "Check the address and amount, then try again." }); } catch {}
       setStatus(`Error: ${e?.message || e}`);
     }
   }
@@ -804,6 +808,7 @@ export default function Dashboard() {
         </div>
         <div className="flex items-center gap-2">
           <Button variant="outline" size="icon" onClick={()=>setNotificationsOpen(v=>!v)}><Bell className="h-4 w-4"/></Button>
+          <a href="/help" className="hidden sm:inline-flex"><Button variant="outline" size="sm">Help</Button></a>
           <Sheet>
             <SheetTrigger asChild>
               <Button variant="outline" size="sm"><Settings className="mr-2 h-4 w-4"/>Settings</Button>
@@ -1090,6 +1095,7 @@ export default function Dashboard() {
             <Button variant="ghost" size="sm" className="flex-1 justify-center gap-2" onClick={()=>document.querySelector('[data-slot=sheet-trigger]')?.dispatchEvent(new Event('click',{bubbles:true}))}><Settings className="h-4 w-4"/>Settings</Button>
           </div>
         </nav>
+        <Toaster richColors position="top-center" />
       </main>
     </div>
   );

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -3,11 +3,13 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import App from './App';
 import Landing from './pages/Landing';
 import Access from './pages/Access';
+import Help from './pages/Help';
 
 const router = createBrowserRouter([
   { path: '/', element: <Landing /> },
   { path: '/dashboard', element: <App /> },
   { path: '/access', element: <Access /> },
+  { path: '/help', element: <Help /> },
   { path: '*', element: <Landing /> },
 ]);
 

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,0 +1,62 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useNavigate } from "react-router-dom";
+
+export default function Help(){
+  const nav = useNavigate();
+  return (
+    <div className="min-h-screen w-full bg-gradient-to-b from-black via-background to-background pb-20">
+      <header className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4">
+        <div className="text-lg font-semibold tracking-tight">Help & FAQ</div>
+        <Button variant="outline" size="sm" onClick={()=>nav('/dashboard')}>Back to Wallet</Button>
+      </header>
+      <main className="mx-auto w-full max-w-6xl px-4 pb-24 space-y-4">
+        <Card>
+          <CardHeader><CardTitle>Getting started</CardTitle></CardHeader>
+          <CardContent className="text-sm text-muted-foreground space-y-2">
+            <div>
+              <div className="font-medium text-foreground">Create wallet</div>
+              Tap “Create Seedless Wallet”. Your smart account is deployed for you automatically.
+            </div>
+            <div>
+              <div className="font-medium text-foreground">Fund wallet</div>
+              Use any exchange/on‑ramp to send assets to your account address shown under Receive.
+            </div>
+            <div>
+              <div className="font-medium text-foreground">Add tokens</div>
+              Press “+ Add” → Search to find a token by name, or use Custom to paste a contract address.
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader><CardTitle>Recovery</CardTitle></CardHeader>
+          <CardContent className="text-sm text-muted-foreground space-y-2">
+            <div>
+              <div className="font-medium text-foreground">Recovery Kit</div>
+              Create a Recovery Kit to back up your owner key. Store the file safely; you can also save it to Google Drive.
+            </div>
+            <div>
+              <div className="font-medium text-foreground">Passkey recovery</div>
+              On supported devices, you can create a Passkey Kit and restore with your device passkey.
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader><CardTitle>Troubleshooting</CardTitle></CardHeader>
+          <CardContent className="text-sm text-muted-foreground space-y-2">
+            <div>
+              <div className="font-medium text-foreground">Network busy or errors</div>
+              Switch network in the dropdown, try again in a few seconds, or check your RPC settings in Settings.
+            </div>
+            <div>
+              <div className="font-medium text-foreground">Token not showing</div>
+              Ensure you added it on the current network. Switch network to view tokens saved for that chain.
+            </div>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
- Adds a Help & FAQ page with quick guides (Create Wallet, Add Token, Recovery Kits, Passkeys, Troubleshooting).\n- Header ‘Help’ shortcut and route /help.\n- Leaves hooks for friendlier toasts and further mobile polish.\n\nNext: wire Drive Save shortcut for Recovery Kit and finish toast replacements across flows.