### PR TITLE
Fix Netlify build: add NEAR wallet selector dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,10 @@
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "^4.1.7",
     "vaul": "^1.1.2",
-    "zod": "^3.25.20"
+    "zod": "^3.25.20",
+    "@near-wallet-selector/core": "^8.3.0",
+    "@near-wallet-selector/modal-ui": "^8.3.0",
+    "@near-wallet-selector/my-near-wallet": "^8.3.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250620.0",


### PR DESCRIPTION
This hotfix adds the required NEAR packages used by src/near/selector.ts on main so production builds succeed.\n\nAdded dependencies:\n- @near-wallet-selector/core\n- @near-wallet-selector/modal-ui (includes styles import)\n- @near-wallet-selector/my-near-wallet\n\nNo functional changes to the app code. This unblocks Netlify by satisfying missing imports reported in the logs.